### PR TITLE
Added CdTe imaging geometry from Ishikawa

### DIFF
--- a/img/foxsi_image_det_cdte.pro
+++ b/img/foxsi_image_det_cdte.pro
@@ -1,0 +1,98 @@
+;+
+;
+; Purpose:
+; 	This routine computes a 2D intensity array for a single CdTe detector, in detector coords.
+; 	No binning choices; works in raw strip coordinates instead.
+;
+;
+; Inputs:
+;		DATA	FOXSI Level 2 data structure
+; 
+; Keywords:
+;		ERANGE	Energy range to include in image (in keV).  Default [4,15]
+;		TRANGE	Time range to include in image (in seconds *from launch*)
+;				Default entire flight
+;		THR_N	Threshold to use for n-side data.
+;		YEAR	2012 or 2014 flight.  Default 2014.
+;		KEEPALL	Keep all events, not just the "good" ones (i.e. those w/no error flags)
+;
+;
+; Example:
+; 	To make an image for D6 for the FOXSI-2 flight:
+;
+;	image3 = foxsi_image_det( data_lvl2_d3, year=2014 )
+;	map3 = make_map( image6, dx=6.74, dy=6.74, xcen=xc, ycen=yc, $
+;	time=time, id='D3' )
+;
+; History:	
+;		2014 Jan	Linz	Wrote routine
+;		Updates throughout 2014 for FOXSI-1 data
+;		2014 Dec	Linz	Updated to work for 2014 data too.
+;		2015 Jan 19	Linz	Drawing flight parameters from file instead of hardcoding.
+;       2015 Feb 23 Ishikawa	made CdTe version
+;-
+
+FUNCTION FOXSI_IMAGE_DET_CDTE, DATA, ERANGE = ERANGE, TRANGE = TRANGE, $
+                          THR_N = THR_N, KEEPALL = KEEPALL, $
+                          YEAR=YEAR, STOP = STOP
+
+	default, erange, [4.,15.]
+;  	if not keyword_set(trange) then trange=[108.3,498.3] ; time range in sec (from launch)
+	default, thr_n, 4.		; n-side keV threshold
+  	default, year, 2014
+  	default, trange, [0,500]
+  	default, year, 2014
+
+;	case year of
+;		2012:	restore, 'data_2012/flight2012-parameters.sav'
+;		2014:	restore, 'data_2014/flight2014-parameters.sav'
+;		else: begin
+;			print, 'Year can only be 2012 or 2014.'
+;			return, -1
+;		end
+;	endcase
+
+	; throw out any potentially bad events
+	if keyword_set( keepall ) then data2=data else data2 = data[ where( data.error_flag eq 0 ) ]
+	
+	; restrict ADC range
+	data2 = data2[ where( data2.hit_energy[1] gt erange[0] and data2.hit_energy[1] lt erange[1]$
+				 and data2.hit_energy[0] gt thr_n ) ]
+
+	tlaunch=69060.0
+	  	istart=long(0)
+	  	i_times = where( data2.wsmr_time ge (trange[0]+tlaunch) and data2.wsmr_time le (trange[1]+tlaunch) )
+		if i_times[0] eq -1 then begin
+			print, 'No events in time range.'
+			return, -1
+		endif
+		istart = i_times[0]
+		iend = i_times[n_elements(i_times)-1]
+
+  	img = fltarr( 128, 128 )
+
+  	for i=istart, iend-1 do begin
+
+	; Note: values are pinned to a pixel corner in data structure.
+	; Change this to the pixel center.
+;    err = get_payload_coords([64,64],detector) - xyerr
+    position = data2[i].hit_xy_det
+    if position[0] lt 64 then begin
+	  ypix=63-(long(position))[0]
+    endif else begin
+	  ypix=191-(long(position))[0]
+    endelse
+    if position[1] lt 64 then begin
+	  xpix=-63+(long(position))[1]
+    endif else begin
+	  xpix=-191+(long(position))[1]
+    endelse
+    img[xpix, ypix] += 1
+    
+  endfor
+  
+	if keyword_set(stop) then stop
+
+return, reverse( img, 2 )
+
+END

--- a/img/foxsi_image_map.pro
+++ b/img/foxsi_image_map.pro
@@ -17,6 +17,7 @@
 ;		YEAR	2012 or 2014 flight.  Default 2014.
 ;		KEEPALL	Keep all events, not just the "good" ones (i.e. those w/no error flags)
 ;		XYCORR	If set, use the position offset for that detector.
+;		CDTE	Signifies CdTe detector.  Use alternate imaging routine.
 ;
 ;
 ; Example:
@@ -26,13 +27,14 @@
 ;	plot_map, map6, /log, /cbar
 ;
 ; History:	
+;		2015 mar 3	Linz	Added functionality to include CdTe geometry from Ishikawa.
 ;		2015 feb 05	Linz	Fixed strip size bug.  Was 60um default, now 75um unless CdTe.
 ;		2015 Jan 19	Linz	Created routine.
 ;-
 
 FUNCTION FOXSI_IMAGE_MAP, DATA,  CENTER, ERANGE = ERANGE, TRANGE = TRANGE, $
                           THR_N = THR_N, KEEPALL = KEEPALL, SMOOTH = SMOOTH, $
-                          YEAR=YEAR, XYCORR=XYCORR, STOP = STOP
+                          YEAR=YEAR, XYCORR=XYCORR, CDTE=CDTE, STOP = STOP
 
 	default, erange, [4.,15.]
 	default, thr_n, 4.		; n-side keV threshold
@@ -59,11 +61,14 @@ FUNCTION FOXSI_IMAGE_MAP, DATA,  CENTER, ERANGE = ERANGE, TRANGE = TRANGE, $
 	time = anytim( time, /yo )
 
 	; Basic image production
-	image = foxsi_image_det( data, trange=trange, erange=erange, $
-		keepall=keepall, year=year, thr_n=thr_n )
+	if keyword_set( CDTE ) then $
+		image = foxsi_image_det_cdte( data, trange=trange, erange=erange, $
+						keepall=keepall, year=year, thr_n=thr_n )	$
+		else $
+		image = foxsi_image_det( data, trange=trange, erange=erange, $
+						keepall=keepall, year=year, thr_n=thr_n )
 
-	if year eq 2014 and ( detnum eq 2 or detnum eq 3) then $
-		stripsize = 6.1879 else stripsize = 7.7349
+	if keyword_set( CDTE ) then stripsize = 6.1879 else stripsize = 7.7349
 		
 	if keyword_set( smooth ) then image = smooth( image, smooth )
 

--- a/img/foxsi_image_solar.pro
+++ b/img/foxsi_image_solar.pro
@@ -1,0 +1,133 @@
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+FUNCTION FOXSI_IMAGE_SOLAR, DATA_IN, DETECTOR, ERANGE = ERANGE, TRANGE = TRANGE, $
+                                  CENTER = CENTER, PSIZE = PSIZE, SIZE = SIZE, $
+                                  XYCOR = XYCOR, THR_N = THR_N, STOP = STOP, ROT=ROT, $
+                                  KEEP_BAD = KEEP_BAD, YEAR = YEAR
+
+; 2015 Feb 18			Adding functionality for FOXSI-2.
+; 2014 March Linz	Reworking this to use foxsi_image_det as a starting point, to 
+; 					avoid strange aliasing effects that showed up earlier.
+;					RETURN VARIABLE IS NOW A PLOTMAP!!
+; 2014 Feb	Linz	Added keywords ROT and KEEP_BAD
+; written March 2013 by Ishikawa, modified by Lindsay
+;        
+; This routine computes a plotmap for a single detector.
+;
+; Inputs:
+;        DATA_IN        FOXSI Level 2 data structure
+;        DETECTOR        Detector number
+;        ERANGE        Energy range to include in image (in keV)
+;        TRANGE        Time range to include in image (in seconds *from launch*)
+;        CENTER        Center of image (arcseconds)
+;        PSIZE        Image pixel size (arcseconds)
+;        SIZE        Image size in pixels
+;        XYCOR        Correct for detector and payload offsets.
+;                        These values are hardcoded and were obtained by
+;                        comparing the flare centroid with RHESSI's.
+;        THR_N        Threshold to use for n-side data.
+;		 ROT		Detector rotation put in by hand.  If not set, detector-dependent
+;					default is used.  (For normal analysis, do not use this keyword.)
+;		 KEEP_BAD	Include events with a nonzero error flag.
+;				YEAR			Year of flight; default 2014
+;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+
+	default, erange, [4.,15.]      	; energy range in keV
+  default, trange, [108.3,498.3] 	; time range in sec (from launch)
+  default, trange, [0.,1200.] 	; time range in sec (from launch)
+  default, center, [0.,0.]    	; img center position in arcsec
+	default, psize,  7.735   		; img pixel size (arcseconds/imagepixel)
+;    default, size,   [2000,2000] 	; size in image pixel numbers
+  default, thr_n,   4.0    		; desired n-side energy threshold
+  default, year, 2014
+
+		if year eq 2014 then $
+			restore, 'data_2014/flight2014-parameters.sav' else if year eq 2012 then $
+			restore, 'data_2012/flight2012-parameters.sav'
+			
+;    ; Here are Ishikawa's offsets used if XYCOR is set:
+;    xerr=[55.4700,    81.490,   96.360,  87.8900,  48.2700,   49.550,   63.450]
+;    yerr=[-135.977, -131.124, -130.241, -92.7310, -95.3080, -120.276, -106.360]
+	case detector of
+			0: shift = shift0
+			1: shift = shift1
+			2: shift = shift2
+			3: shift = shift3
+			4: shift = shift4
+			5: shift = shift5
+			6: shift = shift6
+	else: begin
+			print, 'Detector number out of range (0-6).'
+      return, -1
+  end
+  endcase
+	
+    data = data_in
+
+    ; throw out any potentially bad events
+    if not keyword_set(keep_bad) then data = data[ where( data.error_flag eq 0 ) ]
+    
+    data = data[ where( data.wsmr_time gt trange[0]+tlaunch and $
+    	data.wsmr_time lt trange[1]+tlaunch ) ]
+
+;    ; get rotation angle for this detector.
+;    case detector of
+;        0: rotation =  82.5
+;        1: rotation =  75.0
+;        2: rotation = -67.5
+;        3: rotation = -75.0
+;        4: rotation =  97.5
+;        5: rotation =  90.0
+;        6: rotation = -60.0
+;    else: begin
+;        print, 'Detector number out of range (0-6).'
+;        return, -1
+;    end
+;    endcase
+    
+    ; If ROT is set, this will override the just-set rotation.
+    if keyword_set(rot) then rotation = rot
+    
+  ;  if keyword_set(stop) then stop
+                
+;	; Check to see if pointing is stable over the time interval.
+	if stdev( data.pitch, pitch ) gt 2. or stdev( data.yaw, yaw ) gt 2. then begin
+;		print, 'More than one target is selected.'
+;		return, -1
+	endif
+	
+	; if desired, correct for pointing offset.
+	if keyword_set( xycor ) then begin
+		xcen = pitch - shift[0]
+		ycen = -yaw - shift[1]		; remember the yaw axis is flipped.
+	endif else begin
+		xcen = pitch
+		ycen = -yaw
+	endelse
+
+	; produce image and convert to a map
+	time = t0 + trange[0]
+;	time = anytim( '2012-nov-02 17:55:00' ) + trange[0]
+	image = foxsi_image_det( data, erange=erange, trange=trange, thr_n=thr_n)
+	map = make_map( image, xcen=xcen, ycen=ycen, dx=7.735, dy=7.735, time=anytim(time,/yo) )
+	rot = rot_map( map, rotation )
+	rot.roll_angle = 0.
+
+	; rebin map to desired pixel size.
+	size = size( rot.data )
+	nx = size[1]*7.735/psize
+	ny = size[2]*7.735/psize
+	rebin = rebin_map( rot, nx, ny )
+	
+	; rebin messes up the normalization; restore it here.
+	n=n_elements( where(data.hit_energy[1] gt erange[0] and data.hit_energy[1] lt $
+						erange[1] and data.hit_energy[0] gt thr_n) )
+	scale = float(n) / total(rebin.data)
+	rebin.data *= scale
+	
+	if keyword_set(stop) then stop
+	
+	return, rebin
+
+END

--- a/linz/2014/script-hsi.pro
+++ b/linz/2014/script-hsi.pro
@@ -1,0 +1,113 @@
+t1 = '11-Dec-2014 ' + ['19:00:00','19:30:00']
+
+obs_obj = hsi_obs_summary( obs_time_interval=t1 )
+obs_obj->plotman, /ylog
+
+;
+; SPEX
+;
+
+t_int = '11-Dec-2014 ' + ['19:00:00','19:30:00']
+
+obs_obj = hsi_obs_summary()
+obs_obj-> set, obs_time_interval= t_int
+obs_obj-> plotman, /ylog
+
+obj = hsi_spectrum()
+obj-> set, obs_time_interval= t_int
+obj-> set, decimation_correct= 1                                                             
+obj-> set, rear_decimation_correct= 0                                                        
+obj-> set, pileup_correct= 0                                                                 
+obj-> set, seg_index_mask= [1B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, $
+							0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B, 0B]
+obj-> set, sp_chan_binning= 0
+obj-> set, sp_chan_max= 0
+obj-> set, sp_chan_min= 0
+obj-> set, sp_data_unit= 'Flux'
+obj-> set, sp_energy_binning= 22L
+obj-> set, sp_semi_calibrated= 0B
+obj-> set, sp_time_interval= 30
+obj-> set, sum_flag= 1
+obj-> set, time_range= [0.0000000D, 0.0000000D]
+obj-> set, use_flare_xyoffset= 1
+
+data = obj->getdata()    ; retrieve the spectrum data
+;obj-> plot               ; plot the spectrum
+;obj-> plotman            ; plot the spectrum in plotman
+;obj-> plot, /pl_time     ; plot the time history
+;obj-> plotman, pl_time   ; plot the time history in plotman
+
+specfile = 'linz/hsi_spec_20121102_30sec_D1.fits'
+srmfile = 'linz/hsi_srm_20121102_30sec_D1.fits'
+obj->filewrite, /buildsrm, all_simplify = 0, srmfile = srmfile, specfile = specfile
+
+
+
+obj = ospex()
+obj-> set, spex_specfile= 'linz/hsi_spec_20121102_30sec_D1.fits'
+obj-> set, spex_drmfile= 'linz/hsi_srm_20121102_30sec_D1.fits'
+obj-> set, spex_bk_time_interval=[' 2-Nov-2012 17:50:30.000', ' 2-Nov-2012 17:53:00.000']
+obj-> set, spex_fit_time_interval= [[' 2-Nov-2012 18:01:30.000', ' 2-Nov-2012 18:02:00.000']]
+
+; 0.00753, 0.732
+; 0.00588, 0.751
+; 0.00400, 0.827
+
+; 0.00671391, 0.745797
+; 
+
+obj-> set, spex_erange = [6.,100.]
+;obj-> set, spex_erange = -1
+
+obj -> dofit, /all                                                                                     
+obj -> savefit
+
+;
+; RHESSI images
+;
+
+t2 = '11-Dec-2014 ' + ['19:13:00','19:13:50']
+t2 = '11-Dec-2014 ' + ['19:19:00','19:20:00']
+
+obj = hsi_image()
+obj-> set, det_index_mask= [0B, 0B, 1B, 0B, 1B, 1B, 1B, 1B, 0B]
+obj-> set, im_energy_binning= [4., 12.]
+obj-> set, im_time_interval= t2
+obj-> set, image_dim= [256, 256]
+obj-> set, pixel_size= [4., 4.]
+;obj-> set, use_auto_time_bin= 1L
+;obj-> set, use_flare_xyoffset= 1L
+obj-> set, xyoffset = [-80,80]
+
+obj-> set, smoothing_time= 4.0
+obj-> set, use_phz_stacker= 1L
+
+obj-> set, image_algorithm= 'Clean'
+;obj-> set, natural_weighting= 1L
+;obj-> set, uniform_weighting= 0L
+;obj -> set,clean_show_maps=0L
+obj-> set, clean_niter = 300
+;obj-> set, clean_beam_width_factor = 1.5
+
+;obj -> set, CLEAN_REGRESS_COMBINE=1L
+
+;obj-> set, image_algorithm= 'MEM_NJIT'
+;obj-> set, image_alg = 'EM'
+
+data = obj-> getdata()
+obj-> plotman
+obj->fitswrite
+
+cfits2maps, 'hsi_clean_191300.fits', hsi
+
+
+;
+; RHESSI SPEX from Säm
+;
+
+restore,'rhessi_spectral_fit_foxsi_flare_September2014.sav',/verbose
+plot_oo,average(ebins,1),obs_all(*,0),xrange=[4,12],xstyle=1,yrange=[1e-3,1e4], psym=10
+    for i=0,det_dim-1 do oplot,average(ebins,1),obs_all(*,i), psym=10
+    ;for i=0,det_dim-1 do oplot,average(ebins,1),bkg_all(*,i), psym=10
+    oplot,average(ebins,1),average(bkg_all,2),thick=3,color=1, psym=10
+    oplot,average(ebins,1),average(ph_all,2),thick=3,color=6, psym=10

--- a/linz/2014/script-img.pro
+++ b/linz/2014/script-img.pro
@@ -609,19 +609,25 @@ plot_map, m1, /over, thick=3
 
 trange=[t5_start, t5_end]
 cen = cen5
-m1 = foxsi_image_map( data_lvl2_d6, cen, erange=[4.,6.], trange=trange, thr_n=4., /xycorr, smooth=2 )
-m2 = foxsi_image_map( data_lvl2_d6, cen, erange=[6.,8.], trange=trange, thr_n=4., /xycorr, smooth=2 )
-m3 = foxsi_image_map( data_lvl2_d6, cen, erange=[8.,11.], trange=trange, thr_n=4., /xycorr, smooth=2 )
+m1 = foxsi_image_map( data_lvl2_d6, cen, erange=[4.,6.], trange=trange, thr_n=4., /xycorr, smooth=3 )
+m2 = foxsi_image_map( data_lvl2_d6, cen, erange=[6.,8.], trange=trange, thr_n=4., /xycorr, smooth=3 )
+m3 = foxsi_image_map( data_lvl2_d6, cen, erange=[8.,11.], trange=trange, thr_n=4., /xycorr, smooth=3 )
+
+m1=shift_map(m1,0,-5)
+m2=shift_map(m2,0,-5)
+m3=shift_map(m3,0,-5)
 
 plot_map, m1, cen=[-100,100], fov=3
 
 ratio = m1
 ratio.data = m2.data / m1.data 
-ratio.data[ where(m2.data lt 1.) ] = 0.
-ratio.data[ where(m1.data lt 1.) ] = 0.
+ratio.data[ where(m2.data lt 1.1) ] = 0.
+ratio.data[ where(m1.data lt 1.1) ] = 0.
 plot_map, ratio, /log, cen=[-100,100], fov=3, /cbar
 plot_map, m1, /over
 
+f=file_search('~/data/aia/20141211/*_0094*')
+fits2map, f, aia2
 plot_map, aia2[40], cen=[-90,80], fov=2, /log
 plot_map, m1, /over
 dmap = make_dmap(aia2[40], ref_map=aia2[10] )
@@ -629,8 +635,9 @@ plot_map, dmap, cen=[-90,80], fov=2, /log
 plot_map, m1, /over
 
 smap = make_submap( aia2, cen=[-90,80], fov=3)
-
 dmap = make_dmap(smap[15:44], ref_map=smap[10] )
+plot_map, dmap, cen=[-90,80], fov=2, /log
+plot_map, m1, /over
 
 ratio2 = m1
 ratio2.data = m3.data / m2.data 
@@ -638,4 +645,36 @@ ratio2.data[ where(m3.data lt 0.3) ] = 0.
 ratio2.data[ where(m2.data lt 1.) ] = 0.
 plot_map, ratio2, /log, cen=[-100,100], fov=3, /cbar
 plot_map, m1, /over
+
+m1.id = 'FOXSI Det6'
+smap.id = 'AIA 94A'
+dmap.id = 'AIA 94A'
+
+popen, xsi=5, ysi=5
+loadct, 5
+;plot_map, m1, charsi=1.3, charth=2, xth=5, yth=5, /nodata, cen=[-90,80], fov=2.5, col=255, /nodate
+plot_map, m1, charsi=1.4, charth=2, xth=5, yth=5, cen=[-90,80], fov=2.5, dmax=-0.1, /nodate
+hsi_linecolors
+plot_map, m1, /over, thick=8, col=6, lev=[10,50,90], /per
+plot_map, m2, /over, thick=8, col=7, lev=[30,70,90], /per
+plot_map, m3, /over, thick=8, col=12, lev=[50,90], /per
+xyouts, -160,140, '4-6 keV', col=6, charsi=1.6
+xyouts, -160,125, '6-8 keV', col=7, charsi=1.6
+xyouts, -160,110, '8-11 keV', col=12, charsi=1.6
+
+loadct, 1
+reverse_ct
+plot_map, smap[40], charsi=1.4, charth=2, xth=5, yth=5, cen=[-90,80], fov=2.5, col=255, /nodate
+
+loadct, 5
+plot_map, ratio, charsi=1.4, charth=2, xth=5, yth=5, cen=[-90,80], fov=2.5, /nodate
+
+loadct, 1
+reverse_ct
+plot_map, dmap[29], charsi=1.4, charth=2, xth=5, yth=5, cen=[-90,80], fov=2.5, col=255, dmin=-1, dmax=50 , /nodate
+hsi_linecolors
+plot_map, ratio, /over, thick=8, lev=[10,30], /per, col=255
+
+pclose
+
 

--- a/linz/2014/snippets.pro
+++ b/linz/2014/snippets.pro
@@ -1,0 +1,59 @@
+get_target_data, 4, d0,d1,d2,d3,d4,d5,d6
+t1 = t4_start
+t2 = t4_end
+delta_t = t2 - t1
+bin = 0.3
+spec_d0 = make_spectrum( d0, bin=bin, /correct )
+spec_d1 = make_spectrum( d1, bin=bin, /correct )
+spec_d2 = make_spectrum( d2, bin=bin, /correct )
+spec_d3 = make_spectrum( d3, bin=bin, /correct )
+spec_d4 = make_spectrum( d4, bin=bin, /correct )
+spec_d5 = make_spectrum( d5, bin=bin, /correct )
+spec_d6 = make_spectrum( d6, bin=bin, /correct )
+
+
+module = 5
+
+case module of			&$
+	0: spec = spec_d0			&$
+	1: spec = spec_d1			&$
+	2: spec = spec_d2			&$
+	3: spec = spec_d3			&$
+	4: spec = spec_d4			&$
+	5: spec = spec_d5			&$
+	6: spec = spec_d6			&$
+endcase
+
+nbla = findgen(60)/10.+0.5
+off  = findgen(50)/200.
+nnbla = n_elements(nbla)
+noff = n_elements(off)
+chi_t  = fltarr( nnbla, noff )
+chi_em  = fltarr( nnbla, noff )
+t  = fltarr( nnbla, noff )
+em  = fltarr( nnbla, noff )
+
+for i=0, nnbla-1 do begin &$
+	for j=0, noff-1 do begin &$
+		temp = tempfun7( nbla[i], off[j], spec, 80., ch_t=x, ch_em=y, t=z, em=a,/qu, module=module ) &$
+		chi_t[i,j] = x &$
+		chi_em[i,j] = y &$
+		t[i,j] = z &$
+		em[i,j] = a &$
+	endfor &$
+endfor
+min = min(chi_t,ind_t)
+ind2_t = array_indices(chi_t,ind_t)
+min = min(chi_em,ind_em)
+ind2_em = array_indices(chi_em,ind_em)
+test=tempfun7( nbla[ind2_t[0]], off[ind2_t[1]], spec, 80., /info, module=module )
+test=tempfun7( nbla[ind2_em[0]], off[ind2_em[1]], spec, 80., /info, module=module )
+
+test1 = chi_t / min(chi_t)
+test2 = chi_em / min(chi_em)
+test3 = test1*test2
+plot_map, make_map(test3), /cbar
+plot_map, make_map(test3), /cbar,/log
+min = min(test3,ind)
+ind2 = array_indices(test3,ind)
+test=tempfun5( nbla[ind2[0]], off[ind2[1]], spec_d5, 80., /info )

--- a/linz/2014/snippets2.pro
+++ b/linz/2014/snippets2.pro
@@ -1,0 +1,85 @@
+tr=[t1_pos0_start,t2_pos1_end]
+dt = 15.
+
+d0 = data_lvl2_d0[ where(data_lvl2_d0.error_flag eq 0) ]
+d1 = data_lvl2_d1[ where(data_lvl2_d1.error_flag eq 0) ]
+d4 = data_lvl2_d4[ where(data_lvl2_d4.error_flag eq 0) ]
+d5 = data_lvl2_d5[ where(data_lvl2_d5.error_flag eq 0) ]
+d6 = data_lvl2_d6[ where(data_lvl2_d6.error_flag eq 0) ]
+
+.r
+undefine, m0
+undefine, m1
+undefine, m4
+undefine, m5
+undefine, m6
+for i=0, fix((tr[1]-tr[0]-1)/dt) do begin
+	tint = tr[0]+dt*[i,i+1]
+	if tint[1] lt t1_pos0_end then cen=cen1_pos0 $
+	else if tint[1] lt t1_pos1_end then cen=cen1_pos1 $
+	else if tint[1] lt t1_pos2_end then cen=cen2_pos1
+	n0 = foxsi_image_map(d0, cen, tra=tint, era=[4.,8.])
+	n1 = foxsi_image_map(d1, cen, tra=tint, era=[4.,8.])
+	n4 = foxsi_image_map(d4, cen, tra=tint, era=[4.,8.])
+	n5 = foxsi_image_map(d5, cen, tra=tint, era=[4.,8.])
+	n6 = foxsi_image_map(d6, cen, tra=tint, era=[4.,8.])
+	n0.data = smooth(n0.data, 2)
+	n1.data = smooth(n1.data, 2)
+	n4.data = smooth(n4.data, 2)
+	n5.data = smooth(n5.data, 2)
+	n6.data = smooth(n6.data, 2)
+	push, m0, n0
+	push, m1, n1
+	push, m4, n4
+	push, m5, n5
+	push, m6, n6
+endfor
+end
+;movie_map, m, /log, cen=[0,-250], fov=3
+;movie_map, m0, cen=[0,-250], fov=5, /nosc
+;movie_map, m6, cen=[0,-250], fov=5, /nosc
+
+!p.multi=[0,6,5]
+for i=0,5 do plot_map, m0[i], cen=[0,-250], fov=5, /log, dmin=0.1, dmax=max(m0.data)
+for i=0,5 do plot_map, m1[i], cen=[0,-250], fov=5, /log, dmin=0.1, dmax=max(m1.data)
+for i=0,5 do plot_map, m4[i], cen=[0,-250], fov=5, /log, dmin=0.1, dmax=max(m1.data)
+for i=0,5 do plot_map, m5[i], cen=[0,-250], fov=5, /log, dmin=0.1, dmax=max(m1.data)
+for i=0,5 do plot_map, m6[i], cen=[0,-250], fov=5, /log, dmin=0.1, dmax=max(m6.data)
+
+
+sub = make_submap( m, cen=[-400,-300], fov=3 )
+
+; Make a map for the first target, after all adjustments are done ("target 1, pos 2")
+map_all = foxsi_image_map( data_lvl2_d6, cen1_pos2, tra=[t1_pos2_start,t1_pos2_end])
+plot_map, map_all
+plot_map, map_all, /log
+
+; Try to narrow the data down to an area of the disk.
+cut = area_cut(data_lvl2_d6, [0.,-300], 200., /xy)
+map_cut = foxsi_image_map(cut, cen1_pos2, tra=[t1_pos2_start,t1_pos2_end])       
+plot_map, map_cut
+
+
+d0 = data_lvl2_d0[ where(data_lvl2_d0.error_flag eq 0 and data_lvl2_d0.hit_energy[1] gt 4. and data_lvl2_d0.hit_energy[1] lt 15.) ]
+d1 = data_lvl2_d1[ where(data_lvl2_d1.error_flag eq 0 and data_lvl2_d1.hit_energy[1] gt 4. and data_lvl2_d1.hit_energy[1] lt 15.) ]
+d4 = data_lvl2_d4[ where(data_lvl2_d4.error_flag eq 0 and data_lvl2_d4.hit_energy[1] gt 4. and data_lvl2_d4.hit_energy[1] lt 15.) ]
+d5 = data_lvl2_d5[ where(data_lvl2_d5.error_flag eq 0 and data_lvl2_d5.hit_energy[1] gt 4. and data_lvl2_d5.hit_energy[1] lt 15.) ]
+d6 = data_lvl2_d6[ where(data_lvl2_d6.error_flag eq 0 and data_lvl2_d6.hit_energy[1] gt 4. and data_lvl2_d6.hit_energy[1] lt 15.) ]
+
+plot, d6.wsmr_time, d6.hit_xy_solar[0,*]+360., /psy, yr=[-500,500]
+
+dt = 5.
+dy = 10.
+min1=fix(min(d6.wsmr_time-tlaunch))
+max1=fix(max(d6.wsmr_time-tlaunch))
+nbin1=fix((max1-min1)/dt)
+min2=fix(min(d6.hit_xy_solar[0,*]+360.))
+max2=fix(max(d6.hit_xy_solar[0,*]+360.))
+nbin2=fix((max2-min2)/dy)
+im = hist_2d( d6.wsmr_time-tlaunch, d6.hit_xy_solar[0,*]+360., bin1=dt, bin2=dy, min1=min1, max1=max1, min2=min2, max2=max2 )
+
+t = findgen( nbin1+1 ) + min1
+y = findgen( nbin2+1 ) + min2
+spec = spectrogram(im, t, y)
+spec->plot, yr=[-950,-850], /log
+

--- a/linz/script-selfcalib.pro
+++ b/linz/script-selfcalib.pro
@@ -197,7 +197,7 @@ spec_d6 = make_spectrum( d6, bin=bin, /correct )
 ; 2- make a chisq map using the EM constraint.
 ; 3- choose the map index with the best TOTAL chisq, including both.
 
-nbla = findgen(60)/10.+2.
+nbla = findgen(60)/10.+0.5
 off  = findgen(50)/200.
 nnbla = n_elements(nbla)
 noff = n_elements(off)

--- a/proc/foxsi_level0_to_level1.pro
+++ b/proc/foxsi_level0_to_level1.pro
@@ -32,6 +32,7 @@
 ;		file = 'data_2014/foxsi_level1_data.sav'
 ;
 ; History:	
+;			2015-Mar-03	Linz	Added CdTe keyword for different error flag determination.
 ;			2015-Feb-02	Linz	Added keyword YEAR
 ;			2014-Dec	Linz	Updated to work with 2014 data --
 ;								Eliminated events with HV ne 200V.
@@ -40,7 +41,7 @@
 ;-
 
 FUNCTION	FOXSI_LEVEL0_TO_LEVEL1, FILENAME, DETECTOR = DETECTOR, STOP = STOP, $
-			GROUND = GROUND, YEAR = YEAR
+			GROUND = GROUND, YEAR = YEAR, CDTE = CDTE
 
 	default, year, 2014
 	if not keyword_set(filename) then filename = 'data_2012/foxsi_level0_data.sav'
@@ -302,9 +303,12 @@ FUNCTION	FOXSI_LEVEL0_TO_LEVEL1, FILENAME, DETECTOR = DETECTOR, STOP = STOP, $
 					  data_struct.hit_cm[1] gt data_struct.hit_adc[1])
 		data_struct[check].error_flag = data_struct[check].error_flag + 16
 	
-		check = where(data_struct.hit_xy_det[0] lt 3 or data_struct.hit_xy_det[0] gt 124 or $
-					  data_struct.hit_xy_det[1] lt 3 or data_struct.hit_xy_det[1] gt 124)
-		data_struct[check].error_flag = data_struct[check].error_flag + 32
+		; different geometry for CdTe detectors.
+		if not keyword_set( CDTE ) then begin
+			check = where(data_struct.hit_xy_det[0] lt 3 or data_struct.hit_xy_det[0] gt 124 or $
+					  	data_struct.hit_xy_det[1] lt 3 or data_struct.hit_xy_det[1] gt 124)
+			data_struct[check].error_flag = data_struct[check].error_flag + 32
+		endif
 	
 		check = where(data_struct.livetime gt 2000. or data_struct.livetime lt 1.)
 		data_struct[check].error_flag = data_struct[check].error_flag + 64


### PR DESCRIPTION
This version includes Ishikawa's CdTe imaging routine to get the geometry right for D3.  There's now a /CDTE keyword in the foxsi_image_map routine that will call the CdTe imaging routine, or else Ishikawa's routine can be used on its own to get the image in detector coordinates.

Data was reprocessed to avoid an error code being assigned to hits on a strip that is an edge strip for silicon, but not an edge strip for CdTe.  To use the CdTe data, you should redownload the levels 1 and 2 data from the FTP site.