### PR TITLE
Fixing a little bug

### DIFF
--- a/parameters/init_param.pro
+++ b/parameters/init_param.pro
@@ -2,7 +2,7 @@ COMMON FOXSI_PARAM, t_launch, tlaunch, t1_pos0_start, t1_pos0_end, t1_pos1_start
 t1_pos1_end, t1_pos2_start, t1_pos2_end, t2_pos0_start, t2_pos0_end, t2_pos1_start, $
 t2_pos1_end, t3_pos0_start, t3_pos0_end, t3_pos1_start, t3_pos1_end, t3_pos2_start, $
 t3_pos2_end, t4_start, t_shtr_start, t_shtr_end, t4_end, t5_start, t5_end, $
-date, t0, offset_xy, cen1_pos0, cen1_pos1, cen1_pos2, cen2_pos0, cen2_pos1, $
+date, t0, offset_xy, cen1_pos0, cen1_pos1, cen1_pos2, cen2_pos0, cen2_pos1, cen3_pos0, $
 cen3_pos1, cen3_pos2, cen4, cen5, shift2, shift3, shift6, shift0, shift1, $
 shift4, shift5, flare1, flare2, ar27, ar30, ar32, ar33, ar34, ar35, ar25, ar29, $
 ar31, rot0, rot1, rot2, rot3, rot4, rot5, rot6, detnum0, detnum1, detnum2, detnum3, $


### PR DESCRIPTION
The parameter ‘cen3_pos0’ was included in the parameters/init_param.pro

This variable was lacking for definition at the Start up of the
FoxsiSoft