### PR TITLE
Imagine routine updates for FOXSI CdTe detectors

### DIFF
--- a/img/foxsi_image_det.pro
+++ b/img/foxsi_image_det.pro
@@ -39,9 +39,8 @@ FUNCTION FOXSI_IMAGE_DET, DATA, ERANGE = ERANGE, TRANGE = TRANGE, $
                           THR_N = THR_N, KEEPALL = KEEPALL, cdte=cdte, $
                           YEAR=YEAR, flatfield=flatfield, STOP = STOP
     COMMON FOXSI_PARAM
-	  default, erange, [4.,15.]
-;  	if not keyword_set(trange) then trange=[108.3,498.3] ; time range in sec (from launch)
-	  default, thr_n, 4.		; n-side keV threshold
+	default, erange, [4.,15.]
+        default, thr_n, 4.		; n-side keV threshold
   	default, year, 2014
   	default, trange, [0,500]
   	default, cdte, 0

--- a/img/foxsi_image_map.pro
+++ b/img/foxsi_image_map.pro
@@ -45,7 +45,7 @@ default, thr_n, 4.		; n-side keV threshold
 default, year, 2014
 default, trange, [0,500]
 default, fov, 20.
-
+default, flatfield, 0
 	xc = center[0]
 	yc = center[1]
 	
@@ -56,12 +56,15 @@ default, fov, 20.
 	time = anytim( time, /yo )
 
 	; Basic image production
-	if keyword_set( CDTE ) then $
-		image = foxsi_image_det_cdte( data, trange=trange, erange=erange, $
-						keepall=keepall, year=year, thr_n=thr_n )	$
-		else $
+;	if keyword_set( CDTE ) then $
+;		image = foxsi_image_det_cdte( data, trange=trange, erange=erange, $
+;						keepall=keepall, year=year, thr_n=thr_n )	$
+;		else $
 		image = foxsi_image_det( data, trange=trange, erange=erange, $
-						keepall=keepall, year=year, thr_n=thr_n, flatfield=flatfield )
+						keepall=keepall, year=year, cdte=cdte, thr_n=thr_n, flatfield=flatfield )
+
+print, 'min et max image produced by foxsi_image_det'
+print, minmax(image)
 
 	if keyword_set( CDTE ) then stripsize = 6.1879 else stripsize = 7.7349
 		
@@ -75,7 +78,7 @@ default, fov, 20.
 	image = temp
 
 	map = make_map( image, dx=stripsize, dy=stripsize, xcen=xc, ycen=yc, $
-		time=time, id='Det'+strtrim(detnum,2), fov=2*fov )
+		time=time, id='Det'+strtrim(detnum,2), fov=2*fov, dur=trange[1]-trange[0] )
 
 ;	help, map.data
 

--- a/img/foxsi_image_map.pro
+++ b/img/foxsi_image_map.pro
@@ -59,7 +59,7 @@ default, flatfield, 0
 		image = foxsi_image_det( data, trange=trange, erange=erange, $
 						keepall=keepall, year=year, cdte=cdte, thr_n=thr_n, flatfield=flatfield )
 
-print, 'min et max image produced by foxsi_image_det'
+print, 'min and max image produced by foxsi_image_det'
 print, minmax(image)
 
 	if keyword_set( CDTE ) then stripsize = 6.1879 else stripsize = 7.7349

--- a/img/foxsi_image_map.pro
+++ b/img/foxsi_image_map.pro
@@ -56,10 +56,6 @@ default, flatfield, 0
 	time = anytim( time, /yo )
 
 	; Basic image production
-;	if keyword_set( CDTE ) then $
-;		image = foxsi_image_det_cdte( data, trange=trange, erange=erange, $
-;						keepall=keepall, year=year, thr_n=thr_n )	$
-;		else $
 		image = foxsi_image_det( data, trange=trange, erange=erange, $
 						keepall=keepall, year=year, cdte=cdte, thr_n=thr_n, flatfield=flatfield )
 

--- a/img/get_payload_coords.pro
+++ b/img/get_payload_coords.pro
@@ -1,19 +1,37 @@
 ;+
-;  This function takes a 2D position (or [2,N] array of positions) in detector pixel coordinates
-;  and transforms it to payload coordinates.  For each detector, the origin is in its center.
-; The returned coordinates account for the individual detector rotation as designed.
-; Rotations or translations due to misalignments in the assembly are not included.
+; :Description:
+;   This function takes a 2D position (or [2,N] array of positions) in detector pixel coordinates
+;   and transforms it to payload coordinates.  For each detector, the origin is in its center.
+;   The returned coordinates account for the individual detector rotation as designed.
+;   Rotations or translations due to misalignments in the assembly are not included.
 ; 
-; INPUTS:
+; :Inputs:
 ;         COORDS:                A 2xN array containing [x,y] positions in detector pixel coordinates
 ;         DETECTOR:        Specifies the detector.  Each detector has a different rotation.
+;         
+; :Keyword:
+;         CDTE: Set to 1 to specify that we have a CdTe detector: the pixel size is different        
 ;
-; RETURN VALUE:         A 2XN array containing [x,y] positions in payload coordinates (arcseconds).
-;                        The reference frame is the same as that on the GSE.
+; :RETURN VALUE:
+;   A 2XN array containing [x,y] positions in payload coordinates (arcseconds).
+;      The reference frame is the same as that on the GSE.
+;
+; :History:
+;   2019-Feb-12 Sophie added the rotation in the other direction and the no-reflection problem option for CDTE
+;   2018-Sep-26 Sophie added CdTe keyword and CdTe pixel size
+;   ?? Initial release  
+;   
+; :Note:
+;   In this procedure, a rotation of angle 'rotation' is done, followed by a reflexion over the y axis.
+;   Note that this is equivalent to a rotation of angle '-rotation'.
+;   This is to be in agreement with the rot_map procedure, where a rotation of angle 'rotation'
+;   gives a rotation equivalent to a rotation matrix with angle '-rotation'.
+;   This y reflexion is therefore not specific to a particular detector (Si or CdTe) but reflects an intrinsic distinction
+;   between rotation formulas and rot_map.pro
 ;         
 ;--  
 
-FUNCTION GET_PAYLOAD_COORDS, COORDS, DETECTOR, STOP=STOP
+FUNCTION GET_PAYLOAD_COORDS, COORDS, DETECTOR, CDTE = CDTE, STOP = STOP
 
         case detector of
                 0: rotation =  82.5
@@ -29,23 +47,33 @@ FUNCTION GET_PAYLOAD_COORDS, COORDS, DETECTOR, STOP=STOP
               end
         endcase
         
+        ; If this is a CdTe we do not need to reverse the y axis, and this correspond to make a rotation in the other direction and 
+        ; not fix the vertical reflection problem below
+        IF CDTE EQ 1 THEN rotation= -1.*rotation
+        
+        ; extract coordinates in pixels
+        x = coords[0,*]
+        y = coords[1,*]
+        
         ; Transform pixel coordinates into arcseconds. Angular size of one strip is Tan-1(75um/2m)=7.735"
         ; Also recenter the coordinates so the origin is in the middle of the detector and the pixel numbers
         ; are tied to the middle of the strips.
-        pix_arcsec = 7.735
-        x = ( coords[0,*] - 63.5 )*pix_arcsec
-        y = ( coords[1,*] - 63.5 )*pix_arcsec
+        IF CDTE EQ 1 THEN pix_microm = 60. ELSE pix_microm = 75. ; pixel size in micrometers
+        pix_arcsec = atan(pix_microm*1e-6/2.)*3600.*180/!pi
+        ;pix_arcsec = 7.735
+        x_arc = ( x - 63.5 )*pix_arcsec
+        y_arc = ( y - 63.5 )*pix_arcsec
 
         if keyword_set(stop) then stop
 
         ; Transform to payload coordinates by applying the relevant rotation.
         rotation = rotation*!pi/180        ; switch to radians
-        x_arc = x*cos( rotation ) - y*sin( rotation )
-        y_arc = x*sin( rotation ) + y*cos( rotation )
+        x_arc_rot = x_arc*cos( rotation ) - y_arc*sin( rotation )
+        y_arc_rot = x_arc*sin( rotation ) + y_arc*cos( rotation )
         
         ; Kluge to fix the vertical reflection problem found during post-flight alignment check
-        y_arc = (-1)*y_arc
+        IF CDTE EQ 0 THEN y_arc_rot = (-1)*y_arc_rot
 
-        return, reform([x_arc,y_arc],[2,n_elements(x_arc)])
+        return, reform([x_arc_rot,y_arc_rot],[2,n_elements(x_arc_rot)])
 
 END

--- a/proc/foxsi_level0_to_level1.pro
+++ b/proc/foxsi_level0_to_level1.pro
@@ -277,14 +277,9 @@ FUNCTION	FOXSI_LEVEL0_TO_LEVEL1, FILENAME, DETECTOR = DETECTOR, STOP = STOP, $
     ENDIF
   ENDELSE
 
-  ; Change hit position to payload coordinates: makes the distinction between Si and Cdte
-  IF CDTE EQ 0 THEN BEGIN
+  ; Change hit position to payload coordinates: makes the distinction between Si and Cdte in the call to get_payload_coords
     xy_det = data_struct.hit_xy_det
-;    xy_det[1,*] = 127 - xy_det[1,*] ; reverse Y axis to be in the right detector coordinates
     data_struct.hit_xy_pay = get_payload_coords( xy_det, detector, cdte=cdte )
-  ENDIF ELSE BEGIN
-    data_struct.hit_xy_pay = get_payload_coords( data_struct.hit_xy_det, detector, cdte=cdte )
-  ENDELSE
 
 	; Record position (detector pix coords only) for associated and unrelated pixels.
 ;	data_struct.assoc_adc[0,*,0] = assoc_adc[*,0,*]

--- a/proc/foxsi_level0_to_level1.pro
+++ b/proc/foxsi_level0_to_level1.pro
@@ -15,7 +15,8 @@
 ;			DETECTOR	Detector number (0-6).  Each detector data
 ;			   			must be processed individually.  Default D0
 ;			GROUND		Indicates this is calibration, not flight data.
-;			CDTE      Set to 1 for CdTe detectors. Default is 0.
+;                       YEAR		Year of the flight. Default is 2014.
+;			CDTE      	Set to 1 for CdTe detectors. Default is 0.
 ;
 ; Example:
 ; 	To process level 0 data into Level 1 IDL structures and save them:

--- a/proc/foxsi_level0_to_level1.pro
+++ b/proc/foxsi_level0_to_level1.pro
@@ -145,22 +145,10 @@ FUNCTION	FOXSI_LEVEL0_TO_LEVEL1, FILENAME, DETECTOR = DETECTOR, STOP = STOP, $
 
   ; identify in different cases in nside (ASIC 0 and 1) are on y axis (value=1) or x axis (value=0)
   ; and what are the shift to associate XY detector coordinates
-  IF CDTE EQ 0 THEN BEGIN
 	  nside = 1
 	  pside = 0
 	  strip_shift = [127,63]
-	ENDIF ELSE BEGIN
-	 ; IF year EQ 2014 THEN BEGIN
-	 ;   nside = 0
-	 ;   pside = 1
-	 ;   strip_shift = [63,127]
-	 ; ENDIF 
-	 ; IF year EQ 2018 THEN BEGIN
-	    nside = 1
-	    pside = 0
-	    strip_shift = [127,63]
-	 ; ENDIF
-	ENDELSE
+
   
 	; Identify events where the highest n-side ADC value was on ASIC 0
 	; --------------------


### PR DESCRIPTION
This is a major update of the routines used to do images with FOXSI data. This update does not change the way to do images with Silicon. Any existing code that create images with silicon detectors should not be impacted by these updates. The following is changing:

in foxsi_level0_to_level1, the way to calculate the hit_xy_det is changed for CdTe detector. The way it is calculated is different for FOXSI2 and FOXSI3 CdTe but create an image in the detector coordinates that only need the rotation to become payload coordinates, there is no other fix needed (not even a reflection of the y axis).
in get_payload_coordinates we have a CdTe option that allow to take the CdTe pixel size, do the rotation with the opposite angle than the one use for Silicon, and do not do the y-axis reflection.
in foxsi_level1_to_level2 we introduced a xy_offset for the solar coordinates for FOXSI2 as well as the possibility to correct for a time-evolving roll angle if needed.
in foxsi_image_map we changed the way CdTe is handle, it will in particular call foxsi_image_det with the CdTe keyword instead of calling the foxsi_image_det_cdte routine.
in foxsi_image_det, the CdTe keyword was created to be able to produce a CdTe image in the same way that Silicon images are created.

This set of updates was validated on my computer by creating new level1 and level2 data for all detectors for FOXSI2, then use the new data to look at images in two way:
- using foxsi_image_map for target1 position 0 and make sure the images from the 5 Si detectors and DET3 (CDTE) aligned ;
- using my own routine, make sure that the solar coordinates for the whole flight are in agreement between det6 (Si) and det3 (CdTe)
