### PR TITLE
remove default LET file

### DIFF
--- a/spec/foxsi_ospex.pro
+++ b/spec/foxsi_ospex.pro
@@ -68,7 +68,6 @@ default, radius, 150.
 default, offaxis, 0.
 default, cen_map, cen1_pos2
 default, fwhm, 0.5
-default, let_file, 'efficiency_averaged.sav'
 default, type, 'si'
 default, split_limit, 3.
 default, year, 2014


### PR DESCRIPTION
As a default, the code should use the LET files specified in get_foxsi_deteff.pro. The user can still set the let_file to something else, if desired.